### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from distutils.core import setup
+from setuptools import setup
 import distutils
 from distutils.command.install_lib import install_lib
 import os


### PR DESCRIPTION
setuptools allows the use of `python setup.py develop` which is very
convenient during development