### PR TITLE
* modified the get_default_params

### DIFF
--- a/tests/test_get_default_params.py
+++ b/tests/test_get_default_params.py
@@ -96,5 +96,5 @@ def test_get_default_params_with_list_of_keys():
     }
     up = uparma.UParma(refresh_jsons=False, parameter_data=d["input"])
     default_params = up.get_default_params("omssa_style_1")
-    assert default_params["label"]["translated_key"] == ["-tem", "-tom"]
+    assert default_params["label"]["translated_key"] == ("-tem", "-tom")
     assert default_params["label"]["translated_value"] == "14N"

--- a/uparma/uparma.py
+++ b/uparma/uparma.py
@@ -338,8 +338,8 @@ class UParma(object):
         for key, value in self.parameters.items():
             translated_key = value["key_translations"].get(style, None)
             name = value["name"]
-            if isinstance(translated_key, tuple) is True:
-                translated_key = list(translated_key)
+            if isinstance(translated_key, list) is True:
+                translated_key = tuple(translated_key)
             if translated_key is None:
                 continue
             else:


### PR DESCRIPTION
In the get_default_params the check for the key translations was translating tuple to lists. However, lists cannot be keys in a dictionary...

In uparma.translate this is also set up for converting a list into a tuple. Thus, it should also be the same for the default params. Otherwise, I get a "list is not hashable" error in the omssa wrapper trying to set a list as a key in the udict...