### PR TITLE
Fix/back and forward mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ build
 pyenv
 .idea
 .DS_Store
-docs/.DS_Store
-uparma/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docs/build
 build
 pyenv
 .idea
+.DS_Store
+docs/.DS_Store
+uparma/.DS_Store

--- a/tests/test_back_and_forward_mappings.py
+++ b/tests/test_back_and_forward_mappings.py
@@ -89,18 +89,3 @@ def test_simple_back_and_forward_mapping(test_id):
 
                     elif v["was_translated"] is False:
                         break
-
-
-
-
-                # retour_mapping = up.translate(
-                #     new_input,
-                #     original_style=translated_style,
-                #     translated_style=original_style,
-                # )
-                # retour = {}
-                # for k, v in retour_mapping.items():
-                #     retour[v["translated_key"]] = v["translated_value"]
-                #
-                # print("Reformatted retour", retour)
-                # assert retour == original_dict

--- a/tests/test_back_and_forward_mappings.py
+++ b/tests/test_back_and_forward_mappings.py
@@ -71,17 +71,36 @@ def test_simple_back_and_forward_mapping(test_id):
                 for k, v in forward_mapping.items():
                     if isinstance(v["translated_key"], list):
                         continue
-                    new_input[v["translated_key"]] = v["translated_value"]
-                print("Reformatted forward_mapping", new_input)
+                    if v["was_translated"] is True:
+                        new_input[v["translated_key"]] = v["translated_value"]
+                        print("Reformatted forward_mapping", new_input)
 
-                retour_mapping = up.translate(
-                    new_input,
-                    original_style=translated_style,
-                    translated_style=original_style,
-                )
-                retour = {}
-                for k, v in retour_mapping.items():
-                    retour[v["translated_key"]] = v["translated_value"]
+                        retour_mapping = up.translate(
+                            new_input,
+                            original_style=translated_style,
+                            translated_style=original_style,
+                        )
+                        retour = {}
+                        for k, v in retour_mapping.items():
+                            retour[v["translated_key"]] = v["translated_value"]
 
-                print("Reformatted retour", retour)
-                assert retour == original_dict
+                        print("Reformatted retour", retour)
+                        assert retour == original_dict
+
+                    elif v["was_translated"] is False:
+                        break
+
+
+
+
+                # retour_mapping = up.translate(
+                #     new_input,
+                #     original_style=translated_style,
+                #     translated_style=original_style,
+                # )
+                # retour = {}
+                # for k, v in retour_mapping.items():
+                #     retour[v["translated_key"]] = v["translated_value"]
+                #
+                # print("Reformatted retour", retour)
+                # assert retour == original_dict

--- a/uparma/uparma.py
+++ b/uparma/uparma.py
@@ -283,18 +283,20 @@ class UParma(object):
                     Starting from "Da".. finding 'da' .. looking up ['da', 0]
                     """
                     translated_value = original_value
+                    was_translated = False
                     for _uparma_v, _orgstyle_v in org_value_translations:
                         if _orgstyle_v == original_value:
                             for _uparma_vt, _transtyle_v in trans_value_translations:
                                 if _uparma_v == _uparma_vt:
                                     translated_value = _transtyle_v
+                                    was_translated = True
 
                     template_dict.update(
                         {
                             "translated_key": translated_key,
                             "translated_value": translated_value,
                             "translated_style": translated_style,
-                            "was_translated": True,
+                            "was_translated": was_translated,
                         }
                     )
                 if _name is not None:


### PR DESCRIPTION
Following comet implementation there was an issue with param mapping. 

With this fix, the backward mapping is skipped if there was no matching param while forward mapping in engine_B.

To test it, check out PR26 in uparma-lib with the comet parameters and execute test_back_and_forward_mappings.py with and without the fix.